### PR TITLE
feat: add copy button to history items

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -139,13 +139,25 @@
     <div [ngStyle]="{'display': 'flex', 'flex-direction': 'column', 'height': '100%', 'width': '100%'}">
       <h3 style="margin: 3px;">History</h3>
       <div [ngStyle]="{'flex': '1', 'display': 'flex', 'flex-direction': 'row', 'overflow-x': 'auto'}">
-        <p-listbox 
+        <p-listbox
           [options]="historyOptions"
           [ngStyle]="{'flex': '1'}"
-          optionLabel="label" 
+          optionLabel="label"
           class="custom-listbox"
           (onChange)="onHistorySelect($event)">
-        </p-listbox>        
+          <ng-template let-item pTemplate="item">
+            <div class="history-item">
+              <span>{{ item.label }}</span>
+              <button
+                pButton
+                type="button"
+                icon="pi pi-copy"
+                class="p-button-text p-button-rounded p-button-sm"
+                (click)="copyHistoryItem(item, $event)">
+              </button>
+            </div>
+          </ng-template>
+        </p-listbox>
       </div>
     </div>
   </ng-template>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -143,7 +143,7 @@
           [options]="historyOptions"
           [ngStyle]="{'flex': '1'}"
           optionLabel="label"
-          class="custom-listbox"
+          class="custom-listbox history-listbox"
           (onChange)="onHistorySelect($event)">
           <ng-template let-item pTemplate="item">
             <div class="history-item">

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -60,7 +60,20 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
+    span {
+      flex: 1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    button {
+      flex-shrink: 0;
+      margin-left: 0.25rem;
+    }
   }
+
+:host ::ng-deep .history-listbox .p-listbox {
+  width: 100% !important;
+}
   
   /* Override default listbox container height */
   :host ::ng-deep .p-listbox-list-container {

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -55,6 +55,12 @@
       flex-shrink: 0;
     }
   }
+
+  .history-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
   
   /* Override default listbox container height */
   :host ::ng-deep .p-listbox-list-container {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -517,6 +517,21 @@ export class AppComponent implements OnInit, AfterViewChecked {
     }
   }
 
+  copyHistoryItem(item: HistoryItem, event?: Event) {
+    event?.stopPropagation();
+    const text = `${item.book} ${item.chapter}:${item.verse}`;
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text);
+    } else {
+      const textarea = document.createElement('textarea');
+      textarea.value = text;
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textarea);
+    }
+  }
+
   requestFullscreen() {
     if (this.fullscreenContainer && this.fullscreenContainer.nativeElement.requestFullscreen) {
       this.fullscreenContainer.nativeElement.requestFullscreen();


### PR DESCRIPTION
## Summary
- add copy-to-clipboard button for each history entry
- provide logic to copy verse references
- style history items to accommodate new button

## Testing
- `NG_CLI_ANALYTICS=false npm test -- --watch=false --browsers=ChromeHeadless` *(fails: tsconfig.spec.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_689095b16db083308a22cbec456200af